### PR TITLE
Fix: panic due to negative Repeat count during centering

### DIFF
--- a/term/term.go
+++ b/term/term.go
@@ -3,6 +3,7 @@ package term
 
 import (
 	"fmt"
+	"math"
 	"regexp"
 	"strings"
 
@@ -30,7 +31,7 @@ func CenterLine(s string) string {
 	r := strings.Repeat
 	w, h := Size()
 	size := Length(s)
-	xpad := (w - size) / 2
+	xpad := int(math.Abs(float64((w - size) / 2)))
 	ypad := h / 2
 	return r("\n", ypad) + r(" ", xpad) + s + r("\n", ypad)
 }


### PR DESCRIPTION
The PR fixes a panic caused while centring the progress bar using CenterLine() when the width of the console is small than the width of the progress bar. It is not thoroughly tested because of lack of test files.